### PR TITLE
Don't traceback on SvnErrors.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
             ],
         entry_points={
             'console_scripts': [
-                'svnwrap = svnwrap:main',
+                'svnwrap = svnwrap:mainWithSvnErrorHandling',
                 ],
             },
         description="Wrapper script for Subversion command-line client",

--- a/svnwrap.py
+++ b/svnwrap.py
@@ -803,13 +803,16 @@ def main():
 
     displayConflicts()
 
-def colorTest():
-    for color in sorted(colorDict):
-        writeLn(wrapColor('This is %s' % color, color))
-
-if __name__ == '__main__':
+def mainWithSvnErrorHandling():
     try:
         main()
     except SvnError, e:
         print "svnwrap: %s" % str(e)
         sys.exit(1)
+
+def colorTest():
+    for color in sorted(colorDict):
+        writeLn(wrapColor('This is %s' % color, color))
+
+if __name__ == '__main__':
+    mainWithSvnErrorHandling()


### PR DESCRIPTION
Since the console script was calling svnwrap.main() directly, SvnErrors
would propagate through to the user as a traceback.  Instead, let's have
a routine that will handle SvnErrors, but still call main().  Finally,
use this new routine as the entry point for the svnwrap script.
