### PR TITLE
Fix lost options and args

### DIFF
--- a/svnwrap.py
+++ b/svnwrap.py
@@ -852,7 +852,7 @@ def parseArgs():
                     argsToSkip -= 1
                     arg += s
                     s = ""
-            switchArgs.append(arg)
+                switchArgs.append(arg)
         else:
             posArgs.append(arg)
     return switchArgs, posArgs


### PR DESCRIPTION
I noticed a bug a while back but didn't have much time to track it down at the time.  When using `-rHEAD`, I noticed that `svnwrap` would happily put just the `-r` on the command line.  And while looking at the code to fix that problem, I noticed that the `.append()` statement was outside the while loop, which meant that commands like `svn st -uv` would lose the all but the last option.  This PR fixes both of those issues.
