### PR TITLE
Add the paging to the log and diff commands.

### DIFF
--- a/svnwrap.py
+++ b/svnwrap.py
@@ -24,6 +24,14 @@ sampleIniContents = """
 ##
 ## Define aliases as follows:
 ## project1 = http://server/url/for/project1
+
+[pager]
+## The pager is used by several commands to paginate the output.  You can
+## customize it here, if you don't want to use the default for the system
+## (PAGER).
+##
+## enabled = true
+## cmd = less
 """
 
 # True when debugging.
@@ -908,8 +916,18 @@ def setupPager():
     if not usePager:
         return
 
+    config = svnwrapConfig()
+
+    if config.has_option("pager", "enabled") and \
+            not config.getboolean("pager", "enabled"):
+        return
+
     pagerCmd = "less"
     pagerCmd = getEnviron("PAGER", default=pagerCmd)
+    try:
+        pagerCmd = config.get("pager", "cmd")
+    except ConfigParser.Error:
+        pass
     pagerCmd = getEnviron("SVN_PAGER", default=pagerCmd)
 
     global pager


### PR DESCRIPTION
After using Git so much, I find myself missing the fact that diffs and the logs are run through a pager.  This adds that support on all platforms, but Windows had some quirks:

1) As I suspected, using colorama doesn't really write to stdout, it writes directly to the console.  So there's no real way to get both color and paging.

2) Some of default colors don't really work with native Windows.  It may work fine under Cygwin--I haven't tried, since I never use Cygwin and don't have it installed on my Windows VM.  This is probably something that shoud be fixed in colorama, but it does mean that folks are getting white text instead of colors for any of the "light" colors.

3) I did run it under MsysGit's bash shell, where I have a real less executable and something that mimics a terminal.  It worked better, though still suffered the color issue mentioned above.  Note: I had to remove the `not platformIsWindows` to make it work.

So in the end, I decided to leave the default pager as less, thinking that Windows users probably don't have it, and if they do, then perhaps they're using msys or cygwin where they have a shell that can handle ANSI color sequences.
