### PR TITLE
Remove nightly Python from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - 3.3
   - 3.4
   - 3.5
-  - nightly
   - pypy
 
 install:


### PR DESCRIPTION
According to the [docs](https://docs.travis-ci.com/user/languages/python/#Choosing-Python-versions-to-test-against) nightly points at the 3.7-dev branch, which is even newer than the 3.6-dev branch which isn't tested.  It's probably unwanted to fail the build if `svnwrap` fails to test against this branch.

Another alternative is to continue to test against the nightly Python but add it to to the [allowed failures](https://docs.travis-ci.com/user/customizing-the-build#Rows-that-are-Allowed-to-Fail) category.