### PR TITLE
Remove mutable parameter values

### DIFF
--- a/svnwrap.py
+++ b/svnwrap.py
@@ -376,7 +376,9 @@ def subprocess_popen(*args, **kwargs):
     return subprocess.Popen(*args, **add_restore_signals(kwargs))
 
 
-def svn_call(args=[]):
+def svn_call(args=None):
+    if args is None:
+        args = []
     subprocess_args = [SVN] + args
     ret_code = subprocess_call(subprocess_args)
     if ret_code != 0:

--- a/svnwrap.py
+++ b/svnwrap.py
@@ -964,7 +964,7 @@ def adjust_url_for_wc_path(url, wc_path):
     return new_url
 
 
-def help_wrap(args=[], summary=False):
+def help_wrap(summary=False):
     if summary:
         write("""
 Type 'svn helpwrap' for help on svnwrap extensions.
@@ -1267,7 +1267,7 @@ def main():
 
     elif cmd == 'helpwrap':
         setup_pager()
-        help_wrap(args)
+        help_wrap()
 
     elif cmd == 'st' or cmd == 'stat' or cmd == 'status':
         write_status_lines(svn_gen_status(args))


### PR DESCRIPTION
Mutable default function parameters are dangerous in Python due to the way they are implemented.  See: http://docs.quantifiedcode.com/python-anti-patterns/correctness/mutable_default_value_as_argument.html