### PR TITLE
Add PyPy3 CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.5
   - 3.6
   - pypy
+  - pypy3
 
 install:
   - "pip install -r requirements.txt"


### PR DESCRIPTION
PyPy3 has been released officially and can now be testing against on Travis.

PyPy3 currently supports the Python 3.5 language features.