### PR TITLE
Support Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,17 @@
 language: python
-python:
-  - 2.6
-  - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
-  - 3.6
-  - 3.7
-    dist: xenial
-    sudo: true
-  - pypy
-  - pypy3
+matrix:
+    include:
+        - python: 2.6
+        - python: 2.7
+        - python: 3.3
+        - python: 3.4
+        - python: 3.5
+        - python: 3.6
+        - python: 3.7
+          dist: xenial
+          sudo: true
+        - python: pypy
+        - python: pypy3
 
 install:
   - "pip install -r requirements.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
+    dist: xenial
+    sudo: true
   - pypy
   - pypy3
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Development Status :: 5 - Production/Stable',
     ],
     keywords='svn subversion wrapper',


### PR DESCRIPTION
Fixes #25 

Ubuntu 14.04 does not support the version of OpenSSL required by Python 3.7, so the prescribed way to mitigate this on Travis is to use an Ubuntu 16.04 build VM.