### PR TITLE
Ensure colors comes back as a list.

### DIFF
--- a/svnwrap.py
+++ b/svnwrap.py
@@ -252,7 +252,7 @@ def read_color_scheme():
 
         if key not in valid_keys:
             continue
-        colors = map(lambda x: x.strip() or 'default', value.split(','))
+        colors = list(map(lambda x: x.strip() or 'default', value.split(',')))
         if len(colors) == 1:
             foreground, background = colors[0], None
         elif len(colors) == 2:


### PR DESCRIPTION
In Python 3, `map()` returns an iterator, but we need a list.  So we
need to convert the result with `list()` before continuing.